### PR TITLE
Update .deepsource.toml - autoclosed

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,6 +1,10 @@
 version = 1
 
-test_patterns = ["tests/"]
+test_patterns = [
+  "tests/",
+  "tests/**",
+  "test_*.py",
+]
 
 exclude_patterns = [
   ".github/"


### PR DESCRIPTION
TL;DR: Fixes false positives. See:
https://deepsource.io/docs/concepts/#test_patterns

From Deepsource:
Usage of assert statement in application logic is discouraged. assert is removed with compiling to optimized byte code. Consider raising an exception instead. Ideally, assert statement should be used only in tests.

Python has an option to compile the optimized bytecode and create the respective .pyo files by using the options -O and -OO. When used, these basic optimizations are done:

All the assert statements are removed
All docstrings are removed (when -OO is selected)
Value of the __debug__ built-in variable is set to False
It is recommended not to use assert in non-test files. A better way for internal self-checks is to check explicitly and raise respective error using an if statement.

Tip: Make sure test_patterns are defined in .deepsource.toml to avoid false-positives. Please check the documentation to know more.